### PR TITLE
Fix documentation fragment processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,10 @@ All notable changes to the Ansible VS Code extension will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2021-07-15
+### Fixed
+- Documentation fragments are now also correctly processed in case only one is
+  provided, using YAML flow style. The `file` module is a prominent example.
+
 ## [1.0.0] - 2021-07-14
 - Initial release

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Ansible language support",
   "author": "Tomasz Maciążek",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tomaciazek/vscode-ansible.git"

--- a/server/src/utils/docsParser.ts
+++ b/server/src/utils/docsParser.ts
@@ -22,12 +22,14 @@ export function processDocumentationFragments(
 ): void {
   module.fragments = [];
   if (
-    hasOwnProperty(module.rawDocumentation, 'extends_documentation_fragment') &&
-    module.rawDocumentation.extends_documentation_fragment instanceof Array
+    hasOwnProperty(module.rawDocumentation, 'extends_documentation_fragment')
   ) {
+    const docFragmentNames =
+      module.rawDocumentation.extends_documentation_fragment instanceof Array
+        ? module.rawDocumentation.extends_documentation_fragment
+        : [module.rawDocumentation.extends_documentation_fragment];
     const resultContents = {};
-    for (const docFragmentName of module.rawDocumentation
-      .extends_documentation_fragment) {
+    for (const docFragmentName of docFragmentNames) {
       const docFragment =
         docFragments.get(docFragmentName) ||
         docFragments.get(`ansible.builtin.${docFragmentName}`);


### PR DESCRIPTION
Implementation expected an array for `extends_documentation_fragment`.
Now it also accepts a singular element in YAML flow style.