### PR TITLE
Mimic linter's config file search algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Ansible VS Code extension will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] - 2021-08-10
+### Fixed
+- The configuration file for Ansible Lint is now identified by going up the
+  directory structure, starting from the investigated file, and taking the first
+  `.ansible-lint` file encountered. This effectively mimics the algorithm
+  implemented natively in the linter, while still executing it from the root
+  folder of the workspace.
+
 ## [1.0.5] - 2021-08-08
 ### Fixed
 - Files with CRLF line endings will now display and behave correctly. No more

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Ansible language support",
   "author": "Tomasz Maciążek",
   "license": "MIT",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/tomaciazek/vscode-ansible.git"

--- a/server/src/services/ansibleLint.ts
+++ b/server/src/services/ansibleLint.ts
@@ -1,6 +1,7 @@
 import * as child_process from 'child_process';
 import { ExecException } from 'child_process';
 import { promises as fs } from 'fs';
+import * as path from 'path';
 import { URL } from 'url';
 import { promisify } from 'util';
 import {
@@ -50,27 +51,47 @@ export class AnsibleLint {
   public async doValidate(
     textDocument: TextDocument
   ): Promise<Map<string, Diagnostic[]>> {
-    const docPath = decodeURI(new URL(textDocument.uri).pathname);
     let diagnostics: Map<string, Diagnostic[]> = new Map();
-    let progressTracker;
-    if (this.useProgressTracker) {
-      progressTracker = await this.connection.window.createWorkDoneProgress();
-    }
-
-    const ansibleLintConfigPromise = this.getAnsibleLintConfig(
-      textDocument.uri
-    );
 
     const workingDirectory = decodeURI(
       new URL(this.context.workspaceFolder.uri).pathname
     );
 
-    try {
-      const settings = await this.context.documentSettings.get(
-        textDocument.uri
+    const settings = await this.context.documentSettings.get(textDocument.uri);
+
+    if (settings.ansibleLint.enabled) {
+      let linterArguments = settings.ansibleLint.arguments;
+
+      // Determine linter config file
+      let ansibleLintConfigPath = linterArguments.match(
+        /(?:^|\s)-c\s*(?<sep>[\s'"])(?<conf>.+?)(?:\k<sep>|$)/
+      )?.groups?.conf;
+      if (!ansibleLintConfigPath) {
+        // Config file not provided in arguments -> search for one mimicking the
+        // way ansible-lint looks for it, going up the directory structure
+        const ansibleLintConfigFile = await this.findAnsibleLintConfigFile(
+          textDocument.uri
+        );
+        if (ansibleLintConfigFile) {
+          ansibleLintConfigPath = decodeURI(
+            new URL(ansibleLintConfigFile).pathname
+          );
+          linterArguments = `${linterArguments} -c "${ansibleLintConfigPath}"`;
+        }
+      }
+      linterArguments = `${linterArguments} --offline --nocolor -f codeclimate`;
+
+      const docPath = decodeURI(new URL(textDocument.uri).pathname);
+      let progressTracker;
+      if (this.useProgressTracker) {
+        progressTracker = await this.connection.window.createWorkDoneProgress();
+      }
+      const ansibleLintConfigPromise = this.getAnsibleLintConfig(
+        workingDirectory,
+        ansibleLintConfigPath
       );
 
-      if (settings.ansibleLint.enabled) {
+      try {
         if (progressTracker) {
           progressTracker.begin(
             'ansible-lint',
@@ -81,7 +102,7 @@ export class AnsibleLint {
 
         const [command, env] = withInterpreter(
           settings.ansibleLint.path,
-          `${settings.ansibleLint.arguments} --offline --nocolor -f codeclimate "${docPath}"`,
+          `${linterArguments} --offline --nocolor -f codeclimate "${docPath}"`,
           settings.python.interpreterPath,
           settings.python.activationScript
         );
@@ -100,36 +121,36 @@ export class AnsibleLint {
         if (result.stderr) {
           this.connection.console.info(`[ansible-lint] ${result.stderr}`);
         }
-      }
-    } catch (error) {
-      if (error instanceof Error) {
-        const execError = error as ExecException & {
-          // according to the docs, these are always available
-          stdout: string;
-          stderr: string;
-        };
-        if (execError.code === 2) {
-          diagnostics = this.processReport(
-            execError.stdout,
-            await ansibleLintConfigPromise,
-            workingDirectory
-          );
+      } catch (error) {
+        if (error instanceof Error) {
+          const execError = error as ExecException & {
+            // according to the docs, these are always available
+            stdout: string;
+            stderr: string;
+          };
+          if (execError.code === 2) {
+            diagnostics = this.processReport(
+              execError.stdout,
+              await ansibleLintConfigPromise,
+              workingDirectory
+            );
+          } else {
+            this.connection.window.showErrorMessage(execError.message);
+          }
+
+          if (execError.stderr) {
+            this.connection.console.info(`[ansible-lint] ${execError.stderr}`);
+          }
         } else {
-          this.connection.window.showErrorMessage(execError.message);
+          this.connection.console.error(
+            `Exception in AnsibleLint service: ${JSON.stringify(error)}`
+          );
         }
-
-        if (execError.stderr) {
-          this.connection.console.info(`[ansible-lint] ${execError.stderr}`);
-        }
-      } else {
-        this.connection.console.error(
-          `Exception in AnsibleLint service: ${JSON.stringify(error)}`
-        );
       }
-    }
 
-    if (progressTracker) {
-      progressTracker.done();
+      if (progressTracker) {
+        progressTracker.done();
+      }
     }
     return diagnostics;
   }
@@ -244,14 +265,15 @@ export class AnsibleLint {
   }
 
   private async getAnsibleLintConfig(
-    uri: string
+    workingDirectory: string,
+    configPath: string | undefined
   ): Promise<IAnsibleLintConfig | undefined> {
-    const configPath = await this.getAnsibleLintConfigPath(uri);
     if (configPath) {
-      let config = this.configCache.get(configPath);
+      const absConfigPath = path.resolve(workingDirectory, configPath);
+      let config = this.configCache.get(absConfigPath);
       if (!config) {
-        config = await this.readAnsibleLintConfig(configPath);
-        this.configCache.set(configPath, config);
+        config = await this.readAnsibleLintConfig(absConfigPath);
+        this.configCache.set(absConfigPath, config);
       }
       return config;
     }
@@ -264,7 +286,7 @@ export class AnsibleLint {
       warnList: new Set<string>(),
     };
     try {
-      const configContents = await fs.readFile(new URL(configPath), {
+      const configContents = await fs.readFile(configPath, {
         encoding: 'utf8',
       });
       parseAllDocuments(configContents).forEach((configDoc) => {
@@ -286,7 +308,7 @@ export class AnsibleLint {
     return config;
   }
 
-  private async getAnsibleLintConfigPath(
+  private async findAnsibleLintConfigFile(
     uri: string
   ): Promise<string | undefined> {
     // find configuration path


### PR DESCRIPTION
Since ansible-lint is executed from the root directory of the workspace
the algorithm that it uses to find configuration for a particular file
is not involved. To compensate, the extension now mimics that behavior,
searching the directory structure, going up from the investigated file.

At the same time, it is still possible to force a particular config file
through arguments provided in the extension settings.

The configuration file that is actually used is now correctly identified
for the purpose of marking configured finding groups as warnings.

Fixes #21 